### PR TITLE
fix `}` when happen a breakline

### DIFF
--- a/tools/receive.js
+++ b/tools/receive.js
@@ -5,7 +5,7 @@ const receive = (socket) => {
     socket.on("data",(data) => {
         let line = `received: ${data.toString("utf8")}`
         
-        if (canBreakline()) console.log(`\n${line}}`)
+        if (canBreakline()) console.log(`\n${line}`)
         else console.log(line)
 
         listOfLines.push(false)


### PR DESCRIPTION
# issue 

when happen a breakline is emitter a console.log() with message and `}` in the last part.

example: console.log(´\n${line}}´)

# fix

remove the close parenthesis `}` from console.log()

example: console.log(´\n${line}´)