### PR TITLE
fix loop count

### DIFF
--- a/readline/getIP.js
+++ b/readline/getIP.js
@@ -4,7 +4,7 @@ function GetIP () {
     let Wifi = networkInterfaces()["Wi-Fi"]
     let result = ""
 
-    for (let count = 0; count < Wifi;count++) {
+    for (let count = 0; count < Wifi.length;count++) {
         if (Wifi[count].family == "IPv4") {
             return result = Wifi[count].address
         }


### PR DESCRIPTION
# issue

when running the loop to count length of object wifi, there was no `length` declared in the loop

# fix

declared `length` in object wifi